### PR TITLE
feat(buildings): adding overall plots to the building sector

### DIFF
--- a/frontend/src/config/plotLabels.ts
+++ b/frontend/src/config/plotLabels.ts
@@ -1216,6 +1216,141 @@ export const plotLabels: Record<string, TranslationObject | string> = {
     deDE: 'Holz',
     frFR: 'Bois',
   },
+  'bld_CO2-emissions_coal[Mt]': {
+    enUS: 'Coal',
+    deDE: 'Kohle',
+    frFR: 'Charbon',
+  },
+  'bld_CO2-emissions_district-heating[Mt]': {
+    enUS: 'District-heating',
+    deDE: 'Fernwärme',
+    frFR: 'Chauffage à distance',
+  },
+  'bld_CO2-emissions_electricity[Mt]': {
+    enUS: 'Electricity',
+    deDE: 'Strom',
+    frFR: 'Électricité',
+  },
+  'bld_CO2-emissions_gas[Mt]': {
+    enUS: 'Gas',
+    deDE: 'Gas',
+    frFR: 'Gaz',
+  },
+  'bld_CO2-emissions_heat-pump[Mt]': {
+    enUS: 'Heat-pump',
+    deDE: 'Wärmepumpe',
+    frFR: 'Pompe à chaleur',
+  },
+  'bld_CO2-emissions_heating-oil[Mt]': {
+    enUS: 'Heating-oil',
+    deDE: 'Heizöl',
+    frFR: 'Huile de chauffage',
+  },
+  'bld_CO2-emissions_other[Mt]': {
+    enUS: 'Other',
+    deDE: 'Sonstige',
+    frFR: 'Autre',
+  },
+  'bld_CO2-emissions_solar[Mt]': {
+    enUS: 'Solar-heat',
+    deDE: 'Solarwärme',
+    frFR: 'Chaleur solaire',
+  },
+  'bld_CO2-emissions_wood[Mt]': {
+    enUS: 'Wood',
+    deDE: 'Holz',
+    frFR: 'Bois',
+  },
+  'services_CO2-emissions_heating_coal[Mt]': {
+    enUS: 'Coal',
+    deDE: 'Kohle',
+    frFR: 'Charbon',
+  },
+  'services_CO2-emissions_heating_district-heating[Mt]': {
+    enUS: 'District-heating',
+    deDE: 'Fernwärme',
+    frFR: 'Chauffage à distance',
+  },
+  'services_CO2-emissions_heating_electricity[Mt]': {
+    enUS: 'Electricity',
+    deDE: 'Strom',
+    frFR: 'Électricité',
+  },
+  'services_CO2-emissions_heating_gas[Mt]': {
+    enUS: 'Gas',
+    deDE: 'Gas',
+    frFR: 'Gaz',
+  },
+  'services_CO2-emissions_heating_heat-pump[Mt]': {
+    enUS: 'Heat-pump',
+    deDE: 'Wärmepumpe',
+    frFR: 'Pompe à chaleur',
+  },
+  'services_CO2-emissions_heating_heating-oil[Mt]': {
+    enUS: 'Heating-oil',
+    deDE: 'Heizöl',
+    frFR: 'Huile de chauffage',
+  },
+  'services_CO2-emissions_heating_other[Mt]': {
+    enUS: 'Other',
+    deDE: 'Sonstige',
+    frFR: 'Autre',
+  },
+  'services_CO2-emissions_heating_solar[Mt]': {
+    enUS: 'Solar-heat',
+    deDE: 'Solarwärme',
+    frFR: 'Chaleur solaire',
+  },
+  'services_CO2-emissions_heating_wood[Mt]': {
+    enUS: 'Wood',
+    deDE: 'Holz',
+    frFR: 'Bois',
+  },
+  'bld_hotwater_CO2-emissions_coal[Mt]': {
+    enUS: 'Coal',
+    deDE: 'Kohle',
+    frFR: 'Charbon',
+  },
+  'bld_hotwater_CO2-emissions_district-heating[Mt]': {
+    enUS: 'District-heating',
+    deDE: 'Fernwärme',
+    frFR: 'Chauffage à distance',
+  },
+  'bld_hotwater_CO2-emissions_electricity[Mt]': {
+    enUS: 'Electricity',
+    deDE: 'Strom',
+    frFR: 'Électricité',
+  },
+  'bld_hotwater_CO2-emissions_gas[Mt]': {
+    enUS: 'Gas',
+    deDE: 'Gas',
+    frFR: 'Gaz',
+  },
+  'bld_hotwater_CO2-emissions_heat-pump[Mt]': {
+    enUS: 'Heat-pump',
+    deDE: 'Wärmepumpe',
+    frFR: 'Pompe à chaleur',
+  },
+  'bld_hotwater_CO2-emissions_heating-oil[Mt]': {
+    enUS: 'Heating-oil',
+    deDE: 'Heizöl',
+    frFR: 'Huile de chauffage',
+  },
+  'bld_hotwater_CO2-emissions_other[Mt]': {
+    enUS: 'Other',
+    deDE: 'Sonstige',
+    frFR: 'Autre',
+  },
+  'bld_hotwater_CO2-emissions_solar[Mt]': {
+    enUS: 'Solar-heat',
+    deDE: 'Solarwärme',
+    frFR: 'Chaleur solaire',
+  },
+  'bld_hotwater_CO2-emissions_wood[Mt]': {
+    enUS: 'Wood',
+    deDE: 'Holz',
+    frFR: 'Bois',
+  },
   'bld_Tint-heating_B': {
     enUS: 'A, B',
     deDE: 'A, B',

--- a/frontend/src/config/subtabs/buildings.json
+++ b/frontend/src/config/subtabs/buildings.json
@@ -92,7 +92,13 @@
         "frFR": "Émissions de chauffage",
         "deDE": "Heizungsemissionen"
       },
-      "charts": ["SHGHGEmissionsPerBuildingType", "GHGEmissionsPerCarrier"],
+      "charts": [
+        "GHGEmissionstotalPerCarrier",
+        "SHGHGEmissionsPerBuildingType",
+        "GHGEmissionsheatingPerCarrier",
+        "GHGEmissionsservicesPerCarrier",
+        "GHGEmissionshotwaterPerCarrier"
+      ],
       "route": "building-types-emissions"
     },
     {
@@ -158,7 +164,28 @@
         { "id": "bld_CO2-emissions_heating_B[Mt]", "color": "#388E3C" }
       ]
     },
-    "GHGEmissionsPerCarrier": {
+    "GHGEmissionstotalPerCarrier": {
+      "title": {
+        "enUS": "Territorial CO₂ Emissions from the buildings sector",
+        "frFR": "Émissions totales de CO₂du secteur du batiments",
+        "deDE": "CTerritoriale CO₂-Emissionen aus dem Gebäudesektor"
+      },
+      "type": "StackedArea",
+      "unit": "Mt",
+      "outputs": [
+        { "id": "bld_CO2-emissions_coal[Mt]", "color": "#434348" },
+        { "id": "bld_CO2-emissions_electricity[Mt]", "color": "#f15c80" },
+        { "id": "bld_CO2-emissions_heating-oil[Mt]", "color": "#2b908f" },
+        { "id": "bld_CO2-emissions_gas[Mt]", "color": "#e4d354" },
+        { "id": "bld_CO2-emissions_wood[Mt]", "color": "#5d4037" },
+        { "id": "bld_CO2-emissions_district-heating[Mt]", "color": "#f45b5b" },
+        { "id": "bld_CO2-emissions_heat-pump[Mt]", "color": "#aee791" },
+        { "id": "bld_CO2-emissions_ambient-heat[Mt]", "color": "#7FAEC0" },
+        { "id": "bld_CO2-emissions_other[Mt]", "color": "#f7a35c" },
+        { "id": "bld_CO2-emissions_solar[Mt]", "color": "#e4d354" }
+      ]
+    },
+    "GHGEmissionsheatingPerCarrier": {
       "title": {
         "enUS": "CO2 emissions for residential heating per carrier",
         "frFR": "Émissions de CO2 pour le chauffage résidentiel par vecteur",
@@ -177,6 +204,48 @@
         { "id": "bld_CO2-emissions_heating_ambient-heat[Mt]", "color": "#7FAEC0" },
         { "id": "bld_CO2-emissions_heating_other[Mt]", "color": "#f7a35c" },
         { "id": "bld_CO2-emissions_heating_solar[Mt]", "color": "#e4d354" }
+      ]
+    },
+    "GHGEmissionsservicesPerCarrier": {
+      "title": {
+        "enUS": "Non-residential CO₂ Emissions by energy carrier",
+        "frFR": "Émissions de CO2 non résidentielles par source d’énergie",
+        "deDE": "CO₂-Emissionen im Nichtwohnsektor nach Energieträgern"
+      },
+      "type": "StackedArea",
+      "unit": "Mt",
+      "outputs": [
+        { "id": "services_CO2-emissions_heating_coal[Mt]", "color": "#434348" },
+        { "id": "services_CO2-emissions_heating_electricity[Mt]", "color": "#f15c80" },
+        { "id": "services_CO2-emissions_heating_heating-oil[Mt]", "color": "#2b908f" },
+        { "id": "services_CO2-emissions_heating_gas[Mt]", "color": "#e4d354" },
+        { "id": "services_CO2-emissions_heating_wood[Mt]", "color": "#5d4037" },
+        { "id": "services_CO2-emissions_heating_district-heating[Mt]", "color": "#f45b5b" },
+        { "id": "services_CO2-emissions_heating_heat-pump[Mt]", "color": "#aee791" },
+        { "id": "services_CO2-emissions_heating_ambient-heat[Mt]", "color": "#7FAEC0" },
+        { "id": "services_CO2-emissions_heating_other[Mt]", "color": "#f7a35c" },
+        { "id": "services_CO2-emissions_heating_solar[Mt]", "color": "#e4d354" }
+      ]
+    },
+    "GHGEmissionshotwaterPerCarrier": {
+      "title": {
+        "enUS": "CO₂ Emissions from Residential Hot Water by Energy Source",
+        "frFR": "Émissions de CO₂ liées à l’eau chaude sanitaire résidentielle par source d’énergie",
+        "deDE": "CO₂-Emissionen für die Warmwasserbereitung im Wohnbereich nach Energieträger"
+      },
+      "type": "StackedArea",
+      "unit": "Mt",
+      "outputs": [
+        { "id": "bld_hotwater_CO2-emissions_coal[Mt]", "color": "#434348" },
+        { "id": "bld_hotwater_CO2-emissions_electricity[Mt]", "color": "#f15c80" },
+        { "id": "bld_hotwater_CO2-emissions_heating-oil[Mt]", "color": "#2b908f" },
+        { "id": "bld_hotwater_CO2-emissions_gas[Mt]", "color": "#e4d354" },
+        { "id": "bld_hotwater_CO2-emissions_wood[Mt]", "color": "#5d4037" },
+        { "id": "bld_hotwater_CO2-emissions_district-heating[Mt]", "color": "#f45b5b" },
+        { "id": "bld_hotwater_CO2-emissions_heat-pump[Mt]", "color": "#aee791" },
+        { "id": "bld_hotwater_CO2-emissions_ambient-heat[Mt]", "color": "#7FAEC0" },
+        { "id": "bld_hotwater_CO2-emissions_other[Mt]", "color": "#f7a35c" },
+        { "id": "bld_hotwater_CO2-emissions_solar[Mt]", "color": "#e4d354" }
       ]
     },
     "SHEnergyDemandPerCarrier": {


### PR DESCRIPTION
## What does this change?
Adding 3 plots to the buildings emissions subtab. One for hotwater heating emissions, one for service emissions heating and one for the sum of all the territorial emissions in the building sector.

## Why is this needed?
 This helps having an overview of the emissions made by the buildings sector not only in terms of residential heating

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ x] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## How to test this

<!-- How can reviewers verify this works? -->

- [ X] I've tested this change locally
- [ X] Steps to test: (describe if needed)

Run make run and check if the plots appear.

## Screenshots (if applicable)
<img width="2128" height="1061" alt="image" src="https://github.com/user-attachments/assets/fc9456bf-cbc3-45ae-9aba-9f3f7d421229" />

<!-- For UI changes, drag & drop screenshots here -->

## Related issues

- Closes #
- Related to #Commit 8dab61c and Commit c8c5802


